### PR TITLE
rename Pathlike typing template variable

### DIFF
--- a/pptx_blueprint/__init__.py
+++ b/pptx_blueprint/__init__.py
@@ -2,14 +2,14 @@ import pathlib
 import pptx
 from typing import Union
 
-__Pathlike = Union[str, pathlib.Path]
+_Pathlike = Union[str, pathlib.Path]
 
 
 class Template:
     """Helper class for modifying pptx templates.
     """
 
-    def __init__(self, filename: __Pathlike):
+    def __init__(self, filename: _Pathlike):
         """Initializes a Template-Modifier.
 
         Args:
@@ -29,7 +29,7 @@ class Template:
         """
         pass
 
-    def replace_picture(self, label: str, filename: __Pathlike):
+    def replace_picture(self, label: str, filename: _Pathlike):
         """Replaces rectangle placeholders on one or many slides.
 
         Args:
@@ -47,7 +47,7 @@ class Template:
         """
         pass
 
-    def save(self, filename: __Pathlike):
+    def save(self, filename: _Pathlike):
         """Saves the updated pptx to the specified filepath.
 
         Args:

--- a/pptx_blueprint/__init__.py
+++ b/pptx_blueprint/__init__.py
@@ -1,6 +1,7 @@
 import pathlib
 import pptx
-from typing import Union
+from typing import Union, Iterable
+from pptx.shapes.base import BaseShape
 
 _Pathlike = Union[str, pathlib.Path]
 
@@ -9,7 +10,7 @@ class Template:
     """Helper class for modifying pptx templates.
     """
 
-    def __init__(self, filename: _Pathlike):
+    def __init__(self, filename: _Pathlike) -> None:
         """Initializes a Template-Modifier.
 
         Args:
@@ -19,7 +20,7 @@ class Template:
         self._presentation = pptx.Presentation(filename)
         pass
 
-    def replace_text(self, label: str, text: str, *, scope=None):
+    def replace_text(self, label: str, text: str, *, scope=None) -> None:
         """Replaces text placeholders on one or many slides.
 
         Args:
@@ -29,7 +30,7 @@ class Template:
         """
         pass
 
-    def replace_picture(self, label: str, filename: _Pathlike):
+    def replace_picture(self, label: str, filename: _Pathlike) -> None:
         """Replaces rectangle placeholders on one or many slides.
 
         Args:
@@ -38,7 +39,7 @@ class Template:
         """
         pass
 
-    def replace_table(self, label: str, data):
+    def replace_table(self, label: str, data) -> None:
         """Replaces rectangle placeholders on one or many slides.
 
         Args:
@@ -47,7 +48,15 @@ class Template:
         """
         pass
 
-    def save(self, filename: _Pathlike):
+    def _find_shapes(self, label: str)  -> Iterable(BaseShape):
+        """ Finds all shapes that match the label
+
+        Args:
+            label (str): label of the placeholder (without curly braces)
+        """
+        pass
+
+    def save(self, filename: _Pathlike) -> None:
         """Saves the updated pptx to the specified filepath.
 
         Args:


### PR DESCRIPTION
It didn't work with two underscores so I changed it to one.